### PR TITLE
With-open library improvements

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,6 @@
  {:test {:extra-paths ["test"]
          :exec-fn cognitect.test-runner.api/test
          :extra-deps {io.github.cognitect-labs/test-runner {:git/sha "dfb30dd"
-                                                            :git/tag "v0.5.1"}
-                      nubank/matcher-combinators {:mvn/version "3.8.8"}}
+                                                            :git/tag "v0.5.1"}}
          :main-opts ["-m" "cognitect.test-runner" "-r"
                      ".*[-\\.](expectations|test)(\\..*)?$"]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,1 +1,9 @@
-{:deps {org.clojure/clojure {:mvn/version "1.9.0"}}}
+{:deps {org.clojure/clojure {:mvn/version "1.9.0"}}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :exec-fn cognitect.test-runner.api/test
+         :extra-deps {io.github.cognitect-labs/test-runner {:git/sha "dfb30dd"
+                                                            :git/tag "v0.5.1"}
+                      nubank/matcher-combinators {:mvn/version "3.8.8"}}
+         :main-opts ["-m" "cognitect.test-runner" "-r"
+                     ".*[-\\.](expectations|test)(\\..*)?$"]}}}

--- a/src/jarohen/with_open.clj
+++ b/src/jarohen/with_open.clj
@@ -5,6 +5,29 @@
 
 (set! *warn-on-reflection* true)
 
+(defmacro try-finally
+  "Use try/finally such that an exception in the finally clause does not
+  mask a prior exception in the try block."
+  [body _ finally-body]
+  `(let [*e# (atom nil)]
+     (try
+       ~body
+       (catch Throwable e#
+         (reset! *e# e#))
+       (finally
+         (try
+           ~finally-body
+           (catch Throwable e2#
+             ;; if an exception was thrown by the first try body and by the first finally block then avoid masking the
+             ;; first exception
+             (if @*e#
+               ;; add the new exception to the prior exception
+               (.addSuppressed ^Throwable @*e# e2#)
+               (throw e2#)))
+           (finally
+             (when @*e#
+               (throw @*e#))))))))
+
 (defprotocol Resource
   "Represents a resource with state that should be closed when no longer needed."
   (-close [resource]))
@@ -18,10 +41,10 @@
 
 (defn _with-open [resource f]
   (cond
-    (satisfies? Resource resource) (try
-                                     (f resource)
-                                     (finally
-                                       (-close resource)))
+    (satisfies? Resource resource) (try-finally
+                                    (f resource)
+                                    :finally
+                                    (-close resource))
 
     (fn? resource) (resource f)
     :else (throw (ex-info "Invalid resource passed to with-open+" {:resource resource}))))

--- a/src/jarohen/with_open.clj
+++ b/src/jarohen/with_open.clj
@@ -7,7 +7,18 @@
 
 (defmacro try-finally
   "Use try/finally such that an exception in the finally clause does not
-  mask a prior exception in the try block."
+  mask a prior exception in the try block. The first arg is a form to be
+  evaluated in the main body of the `try`; the second arg is an unused marker
+  for readability (the suggested value is `:finally`); the third arg is a
+  form to be evaluated in the finally block of the `try`.
+
+  Example usage:
+  ```
+  (try-finally
+    (/ 1 0)
+    :finally
+    (println \"Cleaning up\"))
+  ```"
   [body _ finally-body]
   `(let [*e# (atom nil)]
      (try
@@ -49,7 +60,16 @@
     (fn? resource) (resource f)
     :else (throw (ex-info "Invalid resource passed to with-open+" {:resource resource}))))
 
-(defmacro with-open+ [bindings & body]
+(defmacro with-open+
+  "Like `clojure.core/with-open` this evaluates the body in a try expression with
+  the provided bindings that are cleaned up in a finally clause, but provides some
+  additional features:
+  - Bindings support destructuring forms and not just raw names.
+  - Arbitrary types can be treated as resources by wrapping them in higher-order
+    functions (or extending the Resource protocol).
+  - Exceptions thrown in the finally clause will not mask previous exceptions thrown
+    from the body (or inner finally clauses)."
+  [bindings & body]
   (if-let [[binding expr & more-bindings] (seq bindings)]
     `(_with-open ~expr (fn [~binding]
                          (with-open+ [~@more-bindings]

--- a/test/jarohen/with_open_test.clj
+++ b/test/jarohen/with_open_test.clj
@@ -1,0 +1,57 @@
+(ns jarohen.with-open-test
+  (:require
+   [clojure.test :refer [deftest is]]
+   [jarohen.with-open :as with-open]
+   [matcher-combinators.test]))
+
+(deftest test-try-finally-no-exception
+  (let [*result (atom nil)]
+    (is (= 3
+           (with-open/try-finally
+            (+ 1 2)
+            :finally
+            (reset! *result :done))))
+    (is (= :done
+           @*result))))
+
+(deftest test-try-finally-body-exception
+  (let [*result (atom nil)]
+    (is (thrown? ArithmeticException
+                 (with-open/try-finally
+                  (/ 1 0)
+                  :finally
+                  (reset! *result :done))))
+    (is (= :done
+           @*result))))
+
+(deftest test-try-finally-finally-exception
+  (let [*result (atom nil)]
+    (is (thrown? NullPointerException
+                 (with-open/try-finally
+                  (+ 1 2)
+                  :finally
+                  (do
+                    (.toString nil)
+                    (reset! *result :done)))))
+    (is (nil? @*result))))
+
+(deftest test-try-finally-body-and-finally-exception
+  (let [*result (atom nil)]
+    (is (thrown? ArithmeticException
+                 (with-open/try-finally
+                  (/ 1 0)
+                  :finally
+                  (do
+                    (.toString nil)
+                    (reset! *result :done)))))
+    (is (nil? @*result))
+
+    ;; confirm that the exception from the finally block is included in the thrown exception
+    (when-let [ex (is (thrown? Exception
+                               (with-open/try-finally
+                                (/ 1 0)
+                                :finally
+                                (.toString nil))))]
+      (is (= NullPointerException (class (first (.getSuppressed ex))))))))
+
+;; (time (run-tests))

--- a/test/jarohen/with_open_test.clj
+++ b/test/jarohen/with_open_test.clj
@@ -1,8 +1,7 @@
 (ns jarohen.with-open-test
   (:require
    [clojure.test :refer [deftest is]]
-   [jarohen.with-open :as with-open]
-   [matcher-combinators.test]))
+   [jarohen.with-open :as with-open]))
 
 (deftest test-try-finally-no-exception
   (let [*result (atom nil)]


### PR DESCRIPTION
Some small improvements to the `with-open+` macro:

- Port over the `try-finally` macro and use it to avoid masking exceptions from the `with-open+` body when exceptions happen closing the resource.
- Eliminate reflection warnings.
- Add a `Resource` protocol so that any object can be made closeable.